### PR TITLE
ShippingRate validations + tests

### DIFF
--- a/app/models/shipping_rate.rb
+++ b/app/models/shipping_rate.rb
@@ -6,6 +6,8 @@ class ShippingRate
   attr_accessor :origin, :destination, :package
 
   validates :origin, :destination, :package, presence: true
+  validate :valid_locations
+  validate :valid_package
 
   def initialize(attributes = {})
     attributes.each do |name, value|
@@ -28,5 +30,14 @@ class ShippingRate
   def get_rates_from_shipper(shipper)
     response = shipper.find_rates(origin, destination, package)
     response.rates.sort_by(&:price)
+  end
+
+  def valid_locations # OPTIMIZE: it might be fun to make these error messages be more descriptive / include location errors
+    self.errors.add(:origin, "is not valid.") unless self.origin.is_a?(ShippingLocation) && self.origin.valid?
+    self.errors.add(:destination, "is not valid.") unless self.destination.is_a?(ShippingLocation) && self.destination.valid?
+  end
+
+  def valid_package
+    self.errors.add(:package, "is not valid.") unless self.package.is_a?(ActiveShipping::Package)
   end
 end

--- a/spec/models/shipping_rate_spec.rb
+++ b/spec/models/shipping_rate_spec.rb
@@ -2,5 +2,36 @@ require 'rails_helper'
 require 'shipping_rate'
 
 RSpec.describe ShippingRate do
-  pending "validations"
+  describe 'validations' do
+    let(:location1) { ShippingLocation.new(country: 'US', state: 'CA', city: 'Beverly Hills', zip: '90210') }
+    let(:location2) { ShippingLocation.new(country: 'US', state: 'WA', city: 'Seattle', zip: '98101') }
+    let(:package) { ActiveShipping::Package.new(12, [15, 10, 4.5], :units => :imperial) }
+
+    it 'is valid' do
+      r = ShippingRate.new(origin: location1, destination: location2, package: package)
+
+      expect(r).to be_valid
+    end
+
+    it 'requires an origin' do
+      r = ShippingRate.new(destination: location2, package: package)
+
+      expect(r).to be_invalid
+      expect(r.errors).to include :origin
+    end
+
+    it 'requires a destination' do
+      r = ShippingRate.new(origin: location1, package: package)
+
+      expect(r).to be_invalid
+      expect(r.errors).to include :destination
+    end
+
+    it 'requires a package' do
+      r = ShippingRate.new(origin: location1, destination: location2)
+
+      expect(r).to be_invalid
+      expect(r.errors).to include :package
+    end
+  end
 end

--- a/spec/models/shipping_rate_spec.rb
+++ b/spec/models/shipping_rate_spec.rb
@@ -33,5 +33,53 @@ RSpec.describe ShippingRate do
       expect(r).to be_invalid
       expect(r.errors).to include :package
     end
+
+    describe "location validations" do
+      let(:location_string) { "location" }
+      let(:invalid_location) { ShippingLocation.new(country: 'US', state: 'WA', city: 'Seattle') }
+
+      describe "origin" do
+        it "does not accept a string" do
+          r = ShippingRate.new(origin: location_string, destination: location2, package: package)
+
+          expect(r).to be_invalid
+          expect(r.errors).to include :origin
+        end
+
+        it "does not accept an invalid location object" do
+          r = ShippingRate.new(origin: invalid_location, destination: location2, package: package)
+
+          expect(r).to be_invalid
+          expect(r.errors).to include :origin
+        end
+      end
+
+      describe "destination" do
+        it "does not accept a string" do
+          r = ShippingRate.new(origin: location1, destination: location_string, package: package)
+
+          expect(r).to be_invalid
+          expect(r.errors).to include :destination
+        end
+
+        it "does not accept an invalid location object" do
+          r = ShippingRate.new(origin: location1, destination: invalid_location, package: package)
+
+          expect(r).to be_invalid
+          expect(r.errors).to include :destination
+        end
+      end
+    end
+
+    describe "package validations" do
+      let(:package_string) { "package" }
+
+      it "does not accept a string" do
+        r = ShippingRate.new(origin: location1, destination: location2, package: package_string)
+
+        expect(r).to be_invalid
+        expect(r.errors).to include :package
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds tests for basic attribute presence validations.

Also adds validations + tests to check that package and location are valid. This is useful because then we don't have to check package and location validity before creating a rate -- we can do it all at once.
