### PR TITLE
Implements #usps_rates functionality

### DIFF
--- a/app/models/shipping_rate.rb
+++ b/app/models/shipping_rate.rb
@@ -20,16 +20,22 @@ class ShippingRate
     get_rates_from_shipper(ups)
   end
 
-  def usps_rates # TODO: put in actual credentials
-    usps = ActiveShipping::USPS.new(login: 'your usps account number', password: 'your usps password')
-    get_rates_from_shipper(usps)
+  def usps_rates
+    usps = ActiveShipping::USPS.new(login: ENV['ACTIVESHIPPING_USPS_LOGIN'])
+    format_usps_rates(get_rates_from_shipper(usps))
   end
 
   private
 
   def get_rates_from_shipper(shipper)
     response = shipper.find_rates(origin, destination, package)
-    response.rates.sort_by(&:price)
+    response.rates
+  end
+
+  def format_usps_rates(rates)
+    rates.sort_by(&:price).map{ |rate|
+      { rate.service_name => { price: rate.price } }
+    }
   end
 
   def valid_locations # OPTIMIZE: it might be fun to make these error messages be more descriptive / include location errors

--- a/spec/models/shipping_rate_spec.rb
+++ b/spec/models/shipping_rate_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 require 'shipping_rate'
 
 RSpec.describe ShippingRate do
-  describe 'validations' do
-    let(:location1) { ShippingLocation.new(country: 'US', state: 'CA', city: 'Beverly Hills', zip: '90210') }
-    let(:location2) { ShippingLocation.new(country: 'US', state: 'WA', city: 'Seattle', zip: '98101') }
-    let(:package) { ActiveShipping::Package.new(12, [15, 10, 4.5], :units => :imperial) }
+  let(:location1) { ShippingLocation.new(country: 'US', state: 'CA', city: 'Beverly Hills', zip: '90210') }
+  let(:location2) { ShippingLocation.new(country: 'US', state: 'WA', city: 'Seattle', zip: '98101') }
+  let(:package) { ActiveShipping::Package.new(12, [15, 10, 4.5], :units => :imperial) }
 
+  describe 'validations' do
     it 'is valid' do
       r = ShippingRate.new(origin: location1, destination: location2, package: package)
 
@@ -79,6 +79,26 @@ RSpec.describe ShippingRate do
 
         expect(r).to be_invalid
         expect(r.errors).to include :package
+      end
+    end
+  end
+
+  describe '#usps_rates' do
+    let(:shipping_rate) { ShippingRate.new( origin: location1, destination: location2, package: package ) }
+
+    describe "the response" do
+      let(:response) { VCR.use_cassette('USPS') { shipping_rate.usps_rates } }
+
+      it "returns an array of hashes" do
+        expect(response).to be_an_instance_of(Array)
+        expect(response.first).to be_an_instance_of(Hash)
+      end
+
+      it "is sorted by price" do
+        rates = response.map{ |rate| rate.values.first[:price] }
+
+        expect(rates).to be_an_instance_of(Array)
+        expect(rates.sort).to eq(rates)
       end
     end
   end


### PR DESCRIPTION
I made the value of the rates hash be another hash so that if we expand to include more details besides price (e.g. delivery estimate), they can be added to the hash.
